### PR TITLE
fix: #560344 fix save continue for grid reference

### DIFF
--- a/src/Epr.Reprocessor.Exporter.UI.UnitTests/Controllers/RegistrationControllerTests.cs
+++ b/src/Epr.Reprocessor.Exporter.UI.UnitTests/Controllers/RegistrationControllerTests.cs
@@ -1134,7 +1134,7 @@ public class RegistrationControllerTests
     }
 
     [TestMethod]
-    [DataRow("SaveAndContinue", "/")]
+    [DataRow("SaveAndContinue", PagePaths.AddressForNotices)]
     [DataRow("SaveAndComeBackLater", PagePaths.ApplicationSaved)]
     public async Task ProvideSiteGridReference_OnSubmit_ShouldRedirect(string actionButton, string expectedReturnUrl)
     {

--- a/src/Epr.Reprocessor.Exporter.UI/Controllers/RegistrationController.cs
+++ b/src/Epr.Reprocessor.Exporter.UI/Controllers/RegistrationController.cs
@@ -478,7 +478,7 @@ namespace Epr.Reprocessor.Exporter.UI.Controllers
             session.Journey = new List<string> { PagePaths.RegistrationLanding, PagePaths.GridReferenceForEnteredReprocessingSite };
 
             session.RegistrationApplicationSession.ReprocessingSite!.SetSourcePage(PagePaths.GridReferenceForEnteredReprocessingSite);
-            await SaveSession(session, PagePaths.GridReferenceForEnteredReprocessingSite, PagePaths.RegistrationLanding);
+            await SaveSession(session, PagePaths.GridReferenceForEnteredReprocessingSite, PagePaths.AddressForNotices);
 
             SetTempBackLink(PagePaths.AddressOfReprocessingSite, PagePaths.GridReferenceForEnteredReprocessingSite);
 
@@ -496,7 +496,7 @@ namespace Epr.Reprocessor.Exporter.UI.Controllers
                 return View(model);
             }
 
-            return ReturnSaveAndContinueRedirect(buttonAction, "/", PagePaths.ApplicationSaved);
+            return ReturnSaveAndContinueRedirect(buttonAction,PagePaths.AddressForNotices, PagePaths.ApplicationSaved);
         }
 
         [HttpGet]


### PR DESCRIPTION
…after I click on the 'Save and Continue' button on the 'Grid reference <entered address>' screen