### PR TITLE
Regulator name is incorrect for Northern Ireland

### DIFF
--- a/src/Epr.Reprocessor.Exporter.UI/Views/Accreditation/ApplicationSubmissionConfirmation.cshtml
+++ b/src/Epr.Reprocessor.Exporter.UI/Views/Accreditation/ApplicationSubmissionConfirmation.cshtml
@@ -1,11 +1,10 @@
-@using Epr.Reprocessor.Exporter.UI.App.Extensions
 @using Epr.Reprocessor.Exporter.UI.ViewModels.Accreditation;
 
 @model ApplicationSubmissionConfirmationViewModel
 
 @{
     ViewData["Title"] = Localizer["application_submission_confirm_title"];
-    var nationName  = Model.SiteLocation.GetDisplayName();
+    var nationName = Model.SiteLocation.ToString();
 }
 
 <div class="govuk-width-container">


### PR DESCRIPTION
Updated ApplicationSubmissionConfirmation.cshtml to use textual version of UkNation enum.