### PR TITLE
bug fixes #577076 and #576520

### DIFF
--- a/src/Epr.Reprocessor.Exporter.UI.UnitTests/Controllers/Reprocessor/RegistrationControllerTests.cs
+++ b/src/Epr.Reprocessor.Exporter.UI.UnitTests/Controllers/Reprocessor/RegistrationControllerTests.cs
@@ -861,6 +861,8 @@ public class RegistrationControllerTests
         var ReprocessorRegistrationSession = CreateReprocessorRegistrationSession();
         var userData = GetUserDateWithNationIdAndCompanyNumber();
 
+        ReprocessorRegistrationSession.RegistrationApplicationSession.ReprocessingSite = new ReprocessingSite { SourcePage = sourcePage };
+
         _sessionManagerMock.Setup(x => x.GetSessionAsync(It.IsAny<ISession>()))
             .ReturnsAsync(ReprocessorRegistrationSession);
 
@@ -872,11 +874,11 @@ public class RegistrationControllerTests
 
         // Act
         var result = await _controller.AddressForNotices() as ViewResult;
-        var backlink = _controller.ViewBag.BackLinkToDisplay as string;
+        var backlinkViewBag = _controller.ViewBag.BackLinkToDisplay as string;
 
         // Assert
         result.Should().BeOfType<ViewResult>();
-        backlink.Should().Be(backlink);
+        backlinkViewBag.Should().Be(backLink);
     }
 
     [TestMethod]

--- a/src/Epr.Reprocessor.Exporter.UI/Controllers/RegistrationController.cs
+++ b/src/Epr.Reprocessor.Exporter.UI/Controllers/RegistrationController.cs
@@ -547,8 +547,7 @@ namespace Epr.Reprocessor.Exporter.UI.Controllers
             session.Journey = [PagePaths.CountryOfReprocessingSite, PagePaths.PostcodeOfReprocessingSite];
 
             SetBackLink(session, PagePaths.PostcodeOfReprocessingSite);
-
-            session.RegistrationApplicationSession.ReprocessingSite!.SetSourcePage(PagePaths.PostcodeOfReprocessingSite);
+            
             await SaveSession(session, PagePaths.PostcodeOfReprocessingSite);
 
             var sessionLookupAddress = session.RegistrationApplicationSession.ReprocessingSite.LookupAddress;
@@ -982,6 +981,8 @@ namespace Epr.Reprocessor.Exporter.UI.Controllers
 
             var session = await SessionManager.GetSessionAsync(HttpContext.Session) ?? new ReprocessorRegistrationSession();
             session.Journey = [PagePaths.RegistrationLanding, PagePaths.AddressOfReprocessingSite];
+            SetBackLink(session, PagePaths.AddressOfReprocessingSite);
+            session.RegistrationApplicationSession.ReprocessingSite!.SetSourcePage(PagePaths.AddressOfReprocessingSite);
 
             var organisation = HttpContext.GetUserData().Organisations.FirstOrDefault();
 
@@ -1029,9 +1030,7 @@ namespace Epr.Reprocessor.Exporter.UI.Controllers
                     }
                 };
             }
-
-            await SetTempBackLink(PagePaths.TaskList, PagePaths.AddressOfReprocessingSite);
-
+            
             await SaveSession(session, PagePaths.AddressOfReprocessingSite);
 
             return View(model);
@@ -1066,7 +1065,7 @@ namespace Epr.Reprocessor.Exporter.UI.Controllers
         public async Task<IActionResult> CheckAnswers()
         {
             var session = await SessionManager.GetSessionAsync(HttpContext.Session) ?? new ReprocessorRegistrationSession();
-            session.Journey = new List<string> { PagePaths.ConfirmNoticesAddress, PagePaths.CheckAnswers };
+            session.Journey = new List<string> { PagePaths.AddressForNotices, PagePaths.CheckAnswers };
 
             SetBackLink(session, PagePaths.CheckAnswers);
 

--- a/src/Epr.Reprocessor.Exporter.UI/Views/Registration/AddressForNotices.cshtml
+++ b/src/Epr.Reprocessor.Exporter.UI/Views/Registration/AddressForNotices.cshtml
@@ -37,7 +37,7 @@
 
 			@if (!ViewData.ModelState.IsValid)
 			{
-				@await Html.PartialAsync("Partials/Govuk/_Error", ViewData.ModelState.GetModelStateEntry("SelectedOption"))
+				@await Html.PartialAsync("Partials/Govuk/_Error", ViewData.ModelState.GetModelStateEntry("SelectedAddressOptions"))
 			}
 
 			<radios-container>


### PR DESCRIPTION
Bug fixes
577076 - Unhandled error is thrown when user click continue with no selection on address-for-notices screen
576520 - User goes back to previous screen Failed - From enter-reprocessing-site-address