### PR TITLE
Bug/580173 back navigation from   add another overseas reprosite   page generates an exception

### DIFF
--- a/src/Epr.Reprocessor.Exporter.UI.UnitTests/Controllers/Exporter/ExporterControllerTests.cs
+++ b/src/Epr.Reprocessor.Exporter.UI.UnitTests/Controllers/Exporter/ExporterControllerTests.cs
@@ -1436,6 +1436,63 @@ public class ExporterControllerTests
         view.Url.Should().BeEquivalentTo(redirectToUrl);
     }
 
+
+    [TestMethod]
+    [DataRow("SaveAndContinue", PagePaths.BaselConventionAndOECDCodes)]
+    public async Task AddAnotherOverseasReprocessingSite_Redirect_Url_Should_Be_Error_Page(string buttonAction, string previousPath)
+    {
+        //Arrange
+
+        var activeAddress1 = new OverseasAddress
+        {
+            IsActive = false,
+            OverseasAddressWasteCodes = new List<OverseasAddressWasteCodes>(),
+            AddressLine1 = "",
+            AddressLine2 = "",
+            CityOrTown = "",
+            CountryName = "",
+            OrganisationName = "",
+            PostCode = "",
+            SiteCoordinates = "",
+            StateProvince = ""
+        };           
+
+        var session = new ExporterRegistrationSession
+        {
+            ExporterRegistrationApplicationSession = new ExporterRegistrationApplicationSession()
+            {
+                RegistrationMaterialId = null,
+                OverseasReprocessingSites = new OverseasReprocessingSites
+                {
+                    OverseasAddresses = new List<OverseasAddress> { activeAddress1 }
+                }
+            }
+        };
+
+        _sessionManagerMock
+            .Setup(x => x.GetSessionAsync(It.IsAny<ISession>()))
+            .ReturnsAsync(session);
+
+        var model = new AddAnotherOverseasReprocessingSiteViewModel { AddOverseasSiteAccepted = true };
+
+        var backlink = previousPath;
+
+        var validationResult = new FluentValidation.Results.ValidationResult();
+        _validationServiceMock
+            .Setup(v => v.ValidateAsync(model, default))
+            .ReturnsAsync(validationResult);
+
+
+        //Act
+        var result = _controller.AddAnotherOverseasReprocessingSite(model, buttonAction);
+        var redirectResult = await result as RedirectResult;
+
+
+        //Assert
+        redirectResult.Url.Should().Contain("/Error");
+    }
+
+
     [TestMethod]
     [DataRow("SaveAndContinue", PagePaths.CheckYourAnswersForOverseasProcessingSite)]
     public async Task AddAnotherOverseasReprocessingSite_RedirecToUrl_Should_Be_Check_Your_Answers(string buttonAction, string redirectToUrl)

--- a/src/Epr.Reprocessor.Exporter.UI/Controllers/Exporter/ExporterController.cs
+++ b/src/Epr.Reprocessor.Exporter.UI/Controllers/Exporter/ExporterController.cs
@@ -781,15 +781,16 @@ public class ExporterController(
     [Route(PagePaths.AddAnotherOverseasReprocessingSite)]
     public async Task<IActionResult> AddAnotherOverseasReprocessingSite(AddAnotherOverseasReprocessingSiteViewModel model, string buttonAction)
     {
+        var accepted = model.AddOverseasSiteAccepted.GetValueOrDefault();
+
         await SetTempBackLink(PagePaths.BaselConventionAndOECDCodes, PagePaths.AddAnotherOverseasReprocessingSite);
 
         var session = await sessionManager.GetSessionAsync(HttpContext.Session);
 
-        if (session?.ExporterRegistrationApplicationSession.RegistrationMaterialId is null)
+        if (session.ExporterRegistrationApplicationSession.RegistrationMaterialId is null)
         {
             return Redirect("/Error");
         }
-
 
         var validationResult = await validationService.ValidateAsync(model);
         if (!validationResult.IsValid)
@@ -800,7 +801,10 @@ public class ExporterController(
 
         var overseasAddresses = session.ExporterRegistrationApplicationSession.OverseasReprocessingSites.OverseasAddresses.OrderBy(a => a.OrganisationName).ToList();
 
-        overseasAddresses.ForEach(a => a.IsActive = false);
+        if (accepted && buttonAction == SaveAndContinueActionKey)
+        {
+            overseasAddresses.ForEach(a => a.IsActive = false);
+        }        
 
         await SaveSession(session, PagePaths.AddAnotherOverseasReprocessingSite);
 


### PR DESCRIPTION
Fix for bug which generates an exception when clicking the back button on "Add another overseas reprocessing site?" after selecting no which redirects to check your answers page and selecting the back button again.